### PR TITLE
"모드에 따라 리더보드를 구분하여 표시"

### DIFF
--- a/src/tetris/GameArea.java
+++ b/src/tetris/GameArea.java
@@ -340,9 +340,9 @@ public class GameArea extends JPanel {
 		if (rotated.getLeftEdge() < 0)
 			rotated.setX(0);
 		if (rotated.getRightEdge() >= gridColumns)
-			rotated.setX(gridColumns - block.getWidth());
+			rotated.setX(gridColumns - rotated.getWidth());
 		if (rotated.getBottomEdge() >= gridRows)
-			rotated.setY(gridRows - block.getHeight());
+			rotated.setY(gridRows - rotated.getHeight());
 
 		int[][] shape = rotated.getShape();
 		int w = rotated.getWidth();

--- a/src/tetris/GameThread.java
+++ b/src/tetris/GameThread.java
@@ -176,7 +176,7 @@ public class GameThread extends Thread {
 				// 줄이 특정 횟수 삭제되면 아이템 생성
 				// 3을 10으로 고치면 10줄이 삭제될 때마다 아이템이 생성됩니다.
 				// 동작을 쉽게 확인하기 위해 3줄 마다 아이템이 나오도록 3으로 설정해뒀습니다.
-				if (cumClearedLine / 10 != (cumClearedLine + clearedLineNum) / 10) {
+				if (cumClearedLine / 3 != (cumClearedLine + clearedLineNum) / 3) {
 					nextIsItemTurn = true;
 				}
 

--- a/src/tetris/GameThread.java
+++ b/src/tetris/GameThread.java
@@ -35,8 +35,9 @@ public class GameThread extends Thread {
 		// 일반모드
 		if (Tetris.getGameMode() == 0) {
 
+			int gameLevel = Tetris.getGameLevel();
+			
 			while (true) {
-				int gameLevel = Tetris.getGameLevel();
 				
 				ga.spawnBlock(); 						
 					
@@ -104,8 +105,9 @@ public class GameThread extends Thread {
 			}
 		} else { // 아이템모드
 
+			int gameLevel = Tetris.getGameLevel();
+			
 			while (true) {
-				int gameLevel = Tetris.getGameLevel();
 				
 				ga.spawnBlock();
 
@@ -174,7 +176,7 @@ public class GameThread extends Thread {
 				// 줄이 특정 횟수 삭제되면 아이템 생성
 				// 3을 10으로 고치면 10줄이 삭제될 때마다 아이템이 생성됩니다.
 				// 동작을 쉽게 확인하기 위해 3줄 마다 아이템이 나오도록 3으로 설정해뒀습니다.
-				if (cumClearedLine / 3 != (cumClearedLine + clearedLineNum) / 3) {
+				if (cumClearedLine / 10 != (cumClearedLine + clearedLineNum) / 10) {
 					nextIsItemTurn = true;
 				}
 

--- a/src/tetris/LeaderboardForm.java
+++ b/src/tetris/LeaderboardForm.java
@@ -1,6 +1,5 @@
 package tetris;
 
-import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -13,6 +12,7 @@ import javax.swing.AbstractAction;
 import javax.swing.ActionMap;
 import javax.swing.InputMap;
 import javax.swing.JFrame;
+import javax.swing.JLabel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.KeyStroke;
@@ -26,15 +26,26 @@ import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 
 public class LeaderboardForm extends JFrame {
+
 	private JTable leaderboard;
+
 	private DefaultTableModel tm;
-	private String leaderboardFile = "leaderboard";
+	private String[] leaderboardFile = { "leaderboardFile_Normal", "leaderboardFile_Item" };
 	private TableRowSorter<TableModel> sorter;
+	JScrollPane scrollLeaderboard;
+
+	private JLabel[] gameModeLabel;
+	private String gameMode[] = { "일반모드", "아이템모드" };
+	private int curCol;
 
 	public LeaderboardForm() {
 		initThisFrame();
-		initTableData();
+		initLabel();
+
+		initTableData(0);
+		initLeaderboard(tm);
 		initTableSorter();
+		initScrollLeaderboard();
 
 		initControls();
 	}
@@ -48,12 +59,41 @@ public class LeaderboardForm extends JFrame {
 		this.setLocationRelativeTo(null);
 		this.setVisible(false);
 	}
-	
+
+	// 모드, 난이도 표시 레이블 초기화
+	private void initLabel() {
+		gameModeLabel = new JLabel[2];
+		for (int i = 0; i < gameModeLabel.length; i++) {
+			gameModeLabel[i] = new JLabel(gameMode[i]);
+			gameModeLabel[i].setHorizontalAlignment(JLabel.CENTER);
+			gameModeLabel[i].setBounds(200, 10, 200, 30);
+			gameModeLabel[i].setVisible(false);
+			this.add(gameModeLabel[i]);
+		}
+		gameModeLabel[0].setVisible(true);
+	}
+
 	// ESC를 누르면 시작 화면으로 이동
 	private void initControls() {
 		InputMap im = this.getRootPane().getInputMap();
 		ActionMap am = this.getRootPane().getActionMap();
+
+		im.put(KeyStroke.getKeyStroke("RIGHT"), "right");
+		im.put(KeyStroke.getKeyStroke("LEFT"), "left");
 		im.put(KeyStroke.getKeyStroke("ESCAPE"), "back");
+
+		am.put("right", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				moveNextMode();
+			}
+		});
+		am.put("left", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				movePreviousMode();
+			}
+		});
 		am.put("back", new AbstractAction() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -62,13 +102,51 @@ public class LeaderboardForm extends JFrame {
 		});
 	}
 
+	private void moveNextMode() {
+		gameModeLabel[curCol].setVisible(false);
+		scrollLeaderboard.setVisible(false);
+
+		curCol++;
+		if (curCol > gameModeLabel.length - 1) {
+			curCol = 0;
+		}
+
+		gameModeLabel[curCol].setVisible(true);
+
+		remakeScrollLeaderboard(curCol);
+	}
+
+	private void movePreviousMode() {
+		gameModeLabel[curCol].setVisible(false);
+		scrollLeaderboard.setVisible(false);
+
+		curCol--;
+		if (curCol < 0) {
+			curCol = gameModeLabel.length - 1;
+		}
+
+		gameModeLabel[curCol].setVisible(true);
+
+		remakeScrollLeaderboard(curCol);
+	}
+
 	private void goToMainMenu() {
 		this.setVisible(false);
 		Tetris.showStartup();
 	}
 
+	// 현재 모드에 맞는 파일에 따라 보드를 다시 생성한다.
+	private void remakeScrollLeaderboard(int mode) {
+		this.remove(scrollLeaderboard);
+		initTableData(mode);
+		initLeaderboard(tm);
+		initTableSorter();
+		sorter.sort();
+		initScrollLeaderboard();
+	}
+
 	// 파일로부터 데이터 가져오기 (de-serialization)
-	private void initTableData() {
+	private void initTableData(int mode) {
 		String header[] = { "Player", "Score", "Level" };
 		String contents[][] = {};
 
@@ -81,18 +159,19 @@ public class LeaderboardForm extends JFrame {
 
 			@Override // score--> Int 형으로
 			public Class<?> getColumnClass(int columnIndex) {
-				if(columnIndex == 1 ) return Integer.class;
+				if (columnIndex == 1)
+					return Integer.class;
 				return super.getColumnClass(columnIndex).getClass();
 			}
 		};
-		
+
 		Vector columnIdentifier = new Vector();
 		columnIdentifier.add("Player");
 		columnIdentifier.add("Score");
 		columnIdentifier.add("Level");
 
 		try {
-			FileInputStream fs = new FileInputStream(leaderboardFile);
+			FileInputStream fs = new FileInputStream(leaderboardFile[mode]);
 			ObjectInputStream os = new ObjectInputStream(fs);
 
 			// 점수를 문자열이 아닌 int 타입으로 읽어야 두자리 이상의 숫자도 정렬 가능!
@@ -100,17 +179,15 @@ public class LeaderboardForm extends JFrame {
 
 			os.close();
 			fs.close();
-
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-
-		initTable(tm);
 	}
 
-	private void initTable(DefaultTableModel tm) {
+	private void initLeaderboard(DefaultTableModel tm) {
 		leaderboard = new JTable(tm);
-		
+		leaderboard.setFocusable(false);
+
 		// 내용물 중앙 정렬
 		DefaultTableCellRenderer tScheduleCellRenderer = new DefaultTableCellRenderer();
 		tScheduleCellRenderer.setHorizontalAlignment(SwingConstants.CENTER);
@@ -118,12 +195,7 @@ public class LeaderboardForm extends JFrame {
 		for (int i = 0; i < tcmSchedule.getColumnCount(); i++) {
 
 			tcmSchedule.getColumn(i).setCellRenderer(tScheduleCellRenderer);
-
 		}
-
-		JScrollPane scrollPane = new JScrollPane(leaderboard);
-		scrollPane.setBounds(20, 70, 542, 314);
-		getContentPane().add(scrollPane, BorderLayout.CENTER);
 	}
 
 	private void initTableSorter() {
@@ -135,10 +207,17 @@ public class LeaderboardForm extends JFrame {
 		sorter.setSortKeys(keys);
 	}
 
+	// 생성된 테이블 데이터를 사용하여 리더보드 생성
+	private void initScrollLeaderboard() {
+		scrollLeaderboard = new JScrollPane(leaderboard);
+		scrollLeaderboard.setBounds(40, 50, 520, 350);
+		this.add(scrollLeaderboard);
+	}
+
 	// 파일에 데이터 저장하기 (serialization)
 	private void saveLeaderboard() {
 		try {
-			FileOutputStream fs = new FileOutputStream(leaderboardFile);
+			FileOutputStream fs = new FileOutputStream(leaderboardFile[Tetris.getGameMode()]);
 			ObjectOutputStream os = new ObjectOutputStream(fs);
 
 			os.writeObject(tm.getDataVector());
@@ -161,9 +240,17 @@ public class LeaderboardForm extends JFrame {
 		else
 			strGameLevel = "Hard";
 
-		tm.addRow(new Object[] { playerName, score, strGameLevel });
-		sorter.sort();
-		saveLeaderboard();
+		this.remove(scrollLeaderboard); 				// 현재 리더보드 제거
+		initTableData(Tetris.getGameMode()); 			// 현재 모드에 맞는 파일 데이터 읽어오기
+		tm.addRow(new Object[] { playerName, score, strGameLevel }); 	// 읽어온 데이터에 기록 추가
+		initLeaderboard(tm); 							// 읽어온 데이터로 리더보드 생성
+		initTableSorter();								// 리더보드 정렬
+		sorter.sort(); 									// 리더보드 정렬
+		saveLeaderboard(); 								// 파일에 저장
+
+		initScrollLeaderboard(); // leaderboard를 기반으로 보드 생성
+
+		curCol = Tetris.getGameMode();
 
 		this.setVisible(true); // 스코어보드 표시
 	}

--- a/src/tetris/StartupForm.java
+++ b/src/tetris/StartupForm.java
@@ -15,7 +15,7 @@ import javax.swing.SwingConstants;
 
 public class StartupForm extends JFrame {
 	private JLabel title = new JLabel("Tetris");
-	private JLabel guide = new JLabel("메뉴 이동: Up/Down, 메뉴 선택: Enter");
+	private JLabel guide = new JLabel("메뉴 이동: Up/Down, 게임 모드 선택: Right/Left, 메뉴 선택: Enter");
 	private JLabel[] mode = new JLabel[2];
 	private int curMode; // 0이면 일반 모드, 1이면 아이템 모드
 
@@ -32,12 +32,26 @@ public class StartupForm extends JFrame {
 		InputMap im = this.getRootPane().getInputMap();
 		ActionMap am = this.getRootPane().getActionMap();
 
+		// 키보드의 키들을 guide 동작과 연결 
+		for (int i = 0; i < 125; i++) {
+			String text = java.awt.event.KeyEvent.getKeyText(i);
+			if (!text.contains("Unknown keyCode: ")) {
+				im.put(KeyStroke.getKeyStroke(text), "guide");
+			}
+		}
+
 		im.put(KeyStroke.getKeyStroke("UP"), "up");
 		im.put(KeyStroke.getKeyStroke("DOWN"), "down");
 		im.put(KeyStroke.getKeyStroke("ENTER"), "enter");
 		im.put(KeyStroke.getKeyStroke("RIGHT"), "right");
 		im.put(KeyStroke.getKeyStroke("LEFT"), "left");
 
+		am.put("guide", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				displayGuide();
+			}
+		});
 		am.put("up", new AbstractAction() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -121,6 +135,12 @@ public class StartupForm extends JFrame {
 
 		mode[curMode].setVisible(true);
 	}
+	
+	// 다른 키를 눌렀을 경우 사용가능한 키를 표시 
+	// (알파벳, 숫자, F1~F12 에는 작동하지만 그 외의 키는 작동하지 않음. 수정필요
+	private void displayGuide() {
+		guide.setVisible(true);
+	}
 
 	// 선택한 메뉴에 따라 화면 전환
 	private void selectMenu(int curPos) {
@@ -160,8 +180,9 @@ public class StartupForm extends JFrame {
 	private void initLable() {
 		// 키 조작 방법
 		guide.setHorizontalAlignment(SwingConstants.CENTER);
-		guide.setBounds(20, 20, 500, 30);
+		guide.setBounds(50, 20, 500, 30);
 		this.add(guide);
+		guide.setVisible(false);
 
 		int w = this.getWidth();
 		int h = this.getHeight();


### PR DESCRIPTION
모드에 따라 리더보드가 구분되어서 표시되도록 기능을 추가했습니다.

10줄이 삭제될 때마다 아이템이 나오도록 수정하였습니다. 
테스트 할 때는 GameThread에서 더 작은 수로 직접 수정해서 실행하세요!

회전 시 현재 블럭과 배경이 겹치는 오류는 아직 수정하지 못했습니다.   